### PR TITLE
웹툰 카드 및 상세화면 구현

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,12 +1,24 @@
 import 'package:flutter/material.dart';
 import 'package:toonflix/screens/home_screen.dart';
+import 'dart:io';
+
+
+class MyHttpOverrides extends HttpOverrides {
+  @override
+  HttpClient createHttpClient(SecurityContext? context) {
+    return super.createHttpClient(context)
+      ..userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Safari/537.36';
+  }
+}
 
 void main() {
+  HttpOverrides.global = MyHttpOverrides();
+
   runApp(const App());
 }
 
 class App extends StatelessWidget {
-  const App({super.key});
+  const App({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/screens/detail_screen.dart
+++ b/lib/screens/detail_screen.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+
+class DetailScreen extends StatelessWidget {
+  final String title, thumb, id;
+  const DetailScreen({
+    super.key,
+    required this.title,
+    required this.thumb,
+    required this.id,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: AppBar(
+        elevation: 2,
+        backgroundColor: Colors.white,
+        foregroundColor: Colors.green,
+        title: Text(
+          title,
+          style: const TextStyle(
+            fontSize: 24,
+          ),
+        ),
+      ),
+      body: Column(
+        children: [
+          const SizedBox(
+            height: 50,
+          ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Container(
+                width: 250,
+                clipBehavior: Clip.hardEdge,
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(15),
+                  boxShadow: [
+                    BoxShadow(
+                      blurRadius: 15,
+                      offset: const Offset(10, 10),
+                      color: Colors.black.withOpacity(0.3),
+                    )
+                  ],
+                ),
+                child: Image.network(thumb),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:toonflix/models/webtoon_model.dart';
 import 'package:toonflix/services/api_service.dart';
+import 'package:toonflix/widgets/webtoon_widget.dart';
 
 class HomeScreen extends StatelessWidget {
   HomeScreen({super.key});
@@ -26,14 +27,13 @@ class HomeScreen extends StatelessWidget {
         future: webtoons,
         builder: (context, snapshot) {
           if (snapshot.hasData) {
-            return ListView.separated(
-              scrollDirection: Axis.horizontal,
-              itemCount: snapshot.data!.length,
-              itemBuilder: (context, index) {
-                var webtoon = snapshot.data![index];
-                return Text(webtoon.title);
-              },
-              separatorBuilder: (context, index) => const SizedBox(width: 20),
+            return Column(
+              children: [
+                const SizedBox(
+                  height: 50,
+                ),
+                Expanded(child: makeList(snapshot))
+              ],
             );
           }
           return const Center(
@@ -41,6 +41,23 @@ class HomeScreen extends StatelessWidget {
           );
         },
       ),
+    );
+  }
+
+  ListView makeList(AsyncSnapshot<List<WebtoonModel>> snapshot) {
+    return ListView.separated(
+      scrollDirection: Axis.horizontal,
+      itemCount: snapshot.data!.length,
+      padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 20),
+      itemBuilder: (context, index) {
+        var webtoon = snapshot.data![index];
+        return Webtoon(
+          title: webtoon.title,
+          thumb: webtoon.thumb,
+          id: webtoon.id,
+        );
+      },
+      separatorBuilder: (context, index) => const SizedBox(width: 40),
     );
   }
 }

--- a/lib/widgets/webtoon_widget.dart
+++ b/lib/widgets/webtoon_widget.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:toonflix/screens/detail_screen.dart';
+
+class Webtoon extends StatelessWidget {
+  final String title, thumb, id;
+
+  const Webtoon({
+    super.key,
+    required this.title,
+    required this.thumb,
+    required this.id,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () {
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (context) => DetailScreen(
+              title: title,
+              thumb: thumb,
+              id: id,
+            ),
+            fullscreenDialog: true,
+          ),
+        );
+      },
+      child: Column(
+        children: [
+          Container(
+            width: 250,
+            clipBehavior: Clip.hardEdge,
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(15),
+              boxShadow: [
+                BoxShadow(
+                  blurRadius: 15,
+                  offset: const Offset(10, 10),
+                  color: Colors.black.withOpacity(0.3),
+                )
+              ],
+            ),
+            child: Image.network(thumb),
+          ),
+          const SizedBox(
+            height: 10,
+          ),
+          Text(
+            title,
+            style: const TextStyle(
+              fontSize: 22,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
### 요약

- 웹툰 카드 터치 스크롤 및 상세화면 구현

### 변경사항

- main 추가 코드로 image 403에러해결
- gesture 및 natigator.push를 활용하여 상세화면 이동 구현

### 테스트 방법 (Optional)

### 스크린샷 or 동영상 (Optional)

<img width="452" alt="스크린샷 2023-06-29 오전 11 00 42" src="https://github.com/jihs2113/flutterWebtoon/assets/48509331/94bbf3be-f4aa-4fec-8b8c-85c2f3dcbb38">


### 참고자료 (Optional)

Resolves #9 
Closes #9 
